### PR TITLE
xFailOverCluster: CI pipeline runs on changes in source folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - The deploy step is now only run when merged to branch `master` in the
     DSC Community upstream repository (not to branch `master` in a fork
     which always failed due to missing credentials).
+  - Only run CI pipeline on branch `master` when there are changes to files
+    inside the `source` folder.
 
 ### Fixed
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,8 @@ trigger:
     include:
     - master
   paths:
-    exclude:
-    - CHANGELOG.md
+    include:
+    - /source/**/*
   tags:
     include:
     - "v*"


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
- Only run CI pipeline on branch `master` when there are changes to files
    inside the `source` folder.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xfailovercluster/238)
<!-- Reviewable:end -->
