### PR TITLE
xCluster: Fix Describe-block descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Added `en-US` localization folder to pass PSSA rule.
 - xCluster
   - Added script file information to the example `1-CreateFirstNodeOfAFailoverCluster.ps1`.
+  - Fixed Describe-block descriptions ([issue #234](https://github.com/dsccommunity/xFailOverCluster/issues/234)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Changed integration tests to run on a a build image with Windows Server
     2019 since the one we previously used was removed from Azure Pipelines ([issue #233](https://github.com/dsccommunity/xFailOverCluster/issues/233)).
   - Updated CI pipeline to get version from the property `NuGetVersionV2`.
+  - Pin Pester to 4.10.1 in `RequiredModule.psd1` since the tests does
+    not support Pester 5.
+  - Updated repository to use the latest version of the module ModuleBuilder.
 
 ### Fixed
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -8,9 +8,9 @@
 
     invokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    pester                      = 'latest'
+    pester                      = '4.10.1'
     Plaster                     = 'latest'
-    ModuleBuilder               = '1.0.0'
+    ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
     MarkdownLinkCheck           = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 ####################################################
 #          ModuleBuilder Configuration             #
 ####################################################
-CopyDirectories:
+CopyPaths:
     - DSCResources
     - en-US
 Encoding: UTF8

--- a/tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/tests/Unit/MSFT_xCluster.Tests.ps1
@@ -50,7 +50,6 @@ foreach ($moduleVersion in @('2012', '2016'))
 
     try
     {
-
         InModuleScope $script:DSCResourceName {
             $mockAdministratorUserName = 'COMPANY\ClusterAdmin'
             $mockAdministratorPassword = ConvertTo-SecureString -String 'dummyPassW0rd' -AsPlainText -Force
@@ -570,7 +569,7 @@ foreach ($moduleVersion in @('2012', '2016'))
             [MockLibImpersonation]::ReturnValue = $false
             $mockLibImpersonationObject = [MockLibImpersonation]::New()
 
-            Describe "xCluster_$moduleVersion\Set-ImpersonateAs' -Tag 'Helper" {
+            Describe 'xCluster_$moduleVersion\Set-ImpersonateAs' -Tag 'Helper' {
                 Context 'When impersonating credentials fails' {
                     It 'Should throw the correct error message' {
                         Mock -CommandName Add-Type -MockWith {
@@ -583,7 +582,7 @@ foreach ($moduleVersion in @('2012', '2016'))
                 }
             }
 
-            Describe "xCluster_$moduleVersion\Close-UserToken' -Tag 'Helper" {
+            Describe 'xCluster_$moduleVersion\Close-UserToken' -Tag 'Helper' {
                 Context 'When closing user token fails' {
                     It 'Should throw the correct error message' {
                         Mock -CommandName Add-Type -MockWith {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
- xFailOverCluster
  - Pin Pester to 4.10.1 in `RequiredModule.psd1` since the tests does
    not support Pester 5.
  - Updated repository to use the latest version of the module ModuleBuilder.
- xCluster
  - Fixed Describe-block descriptions (issue #234).

#### This Pull Request (PR) fixes the following issues
- Fixes #234

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xfailovercluster/242)
<!-- Reviewable:end -->
