### PR TITLE
xCluster: Make DomainAdministratorCredential optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - xCluster
   - Added script file information to the example `1-CreateFirstNodeOfAFailoverCluster.ps1`.
   - Fixed Describe-block descriptions ([issue #234](https://github.com/dsccommunity/xFailOverCluster/issues/234)).
+  - Made DomainAdministratorCredential optional ([issue #164](https://github.com/dsccommunity/xFailOverCluster/issues/164))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ the target node ($env:COMPUTERNAME) to the cluster.
   for cluster communication. To remove networks assigned an IP address through DHCP
   use the resource xClusterNetwork to change the role of the network. This parameter
   is only used during the creation of the cluster and is not monitored after.
-* **`[String]` DomainAdministratorCredential** _(Required)_: Credential used to
-  create the failover cluster in Active Directory.
+* **`[PSCredential]` DomainAdministratorCredential** _(Write)_: Credential used to
+  create the failover cluster in Active Directory. If this is not specified then 
+  the cluster computer object must have been prestaged as per the
+  [documentation](https://docs.microsoft.com/en-us/windows-server/failover-clustering/prestage-cluster-adds).
+    * If `PsDscRunAsCredential` is used, then that account must have been granted 
+    Full Control over the Cluster Name Object in Active Directory.
+    * Otherwise the Computer Account must have been granted Full Control 
+    over the Cluster Name Object in Active Directory.
+
 
 #### Examples for xCluster
 

--- a/source/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
+++ b/source/DSCResources/MSFT_xCluster/MSFT_xCluster.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
         [System.String[]]
         $IgnoreNetwork,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $DomainAdministratorCredential
     )
@@ -56,10 +56,13 @@ function Get-TargetResource
         $errorMessage = $script:localizedData.TargetNodeDomainMissing
         New-InvalidOperationException -Message $errorMessage
     }
-
+    $context = $null
     try
     {
-        ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        if ($PSBoundParameters.ContainsKey('DomainAdministratorCredential'))
+        {
+            ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        }
 
         $cluster = Get-Cluster -Name $Name -Domain $computerInformation.Domain
         if ($null -eq $cluster)
@@ -87,6 +90,7 @@ function Get-TargetResource
         IgnoreNetwork                 = $IgnoreNetwork
         DomainAdministratorCredential = $DomainAdministratorCredential
     }
+
 }
 
 <#
@@ -136,7 +140,7 @@ function Set-TargetResource
         [System.String[]]
         $IgnoreNetwork,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $DomainAdministratorCredential
     )
@@ -168,7 +172,11 @@ function Set-TargetResource
 
     try
     {
-        ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        $context = $null
+        if ($PSBoundParameters.ContainsKey('DomainAdministratorCredential'))
+        {
+            ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        }
 
         if ($bCreate)
         {
@@ -302,7 +310,7 @@ function Test-TargetResource
         [System.String[]]
         $IgnoreNetwork,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $DomainAdministratorCredential
     )
@@ -320,7 +328,11 @@ function Test-TargetResource
 
     try
     {
-        ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        $context = $null
+        if ($PSBoundParameters.ContainsKey('DomainAdministratorCredential'))
+        {
+            ($oldToken, $context, $newToken) = Set-ImpersonateAs -Credential $DomainAdministratorCredential
+        }
 
         $cluster = Get-Cluster -Name $Name -Domain $ComputerInfo.Domain
 

--- a/source/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+++ b/source/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
@@ -5,6 +5,6 @@ class MSFT_xCluster : OMI_BaseResource
 {
     [Key, Description("Name of the Cluster")] String Name;
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
-    [Required, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
+    [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource xClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];
 };

--- a/tests/Unit/MSFT_xCluster.Tests.ps1
+++ b/tests/Unit/MSFT_xCluster.Tests.ps1
@@ -228,6 +228,25 @@ foreach ($moduleVersion in @('2012', '2016'))
                         }
                     }
 
+                    Context 'When no DomainAdministratorCredential is provided' {
+
+                        $withNoDomainAdministratorCredential = $mockDefaultParameters.Clone()
+                        $withNoDomainAdministratorCredential.Remove('DomainAdministratorCredential')
+
+                        It 'Should not call Set-ImpersonateAs' {
+                            Mock -CommandName Set-ImpersonateAs -MockWith {Return 0}
+
+                            $getTargetResourceResult = Get-TargetResource @withNoDomainAdministratorCredential
+
+                            Assert-MockCalled -CommandName Set-ImpersonateAs -Exactly -Times 0 -Scope It
+                        }
+                        It 'Should return empty DomainAdministratorCredential in the hash' {
+
+                            $getTargetResourceResult = Get-TargetResource @withNoDomainAdministratorCredential
+                            $getTargetResourceResult.DomainAdministratorCredential | Should -BeNullOrEmpty
+                        }
+                    }
+
                     Assert-VerifiableMock
                 }
             }
@@ -344,6 +363,21 @@ foreach ($moduleVersion in @('2012', '2016'))
                                     Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
                                 }
                             }
+
+                            Context 'When no DomainAdministratorCredential is provided' {
+                                It 'Should not call Set-ImpersonateAs' {
+                                    $withNoDomainAdministratorCredential = $mockDefaultParameters.Clone()
+                                    $withNoDomainAdministratorCredential.Remove('DomainAdministratorCredential')
+                                    Mock -CommandName Set-ImpersonateAs -MockWith {Return 0}
+
+                                    {Set-TargetResource @withNoDomainAdministratorCredential} | Should Not Throw
+
+                                    Assert-MockCalled -CommandName Set-ImpersonateAs -Exactly -Times 0 -Scope It
+                                    Assert-MockCalled -CommandName New-Cluster -Exactly -Times 1 -Scope It
+                                    Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
+                                    Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 0 -Scope It
+                                }
+                            }
                         }
 
                         Context 'When Get-Cluster throws an error' {
@@ -379,15 +413,31 @@ foreach ($moduleVersion in @('2012', '2016'))
                     }
 
                     Context 'When the cluster exist but the node is not part of the cluster' {
-                        It 'Should call Add-ClusterNode cmdlet' {
+                        BeforeAll {
                             Mock -CommandName Get-ClusterNode
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
-
+                        }
+                        It 'Should call Add-ClusterNode cmdlet' {
                             { Set-TargetResource @mockDefaultParameters } | Should -Not -Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 1 -Scope It
+                        }
+
+                        Context 'When no DomainAdministratorCredential is provided' {
+                            It 'Should not call Set-ImpersonateAs' {
+                                $withNoDomainAdministratorCredential = $mockDefaultParameters.Clone()
+                                $withNoDomainAdministratorCredential.Remove('DomainAdministratorCredential')
+                                Mock -CommandName Set-ImpersonateAs -MockWith {Return 0}
+
+                                {Set-TargetResource @withNoDomainAdministratorCredential} | Should Not Throw
+
+                                Assert-MockCalled -CommandName Set-ImpersonateAs -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
+                                Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 1 -Scope It
+                            }
                         }
                     }
 
@@ -447,6 +497,18 @@ foreach ($moduleVersion in @('2012', '2016'))
 
                         Assert-VerifiableMock
                     }
+
+                    Context 'When no DomainAdministratorCredential is provided' {
+                        It 'Should not call Set-ImpersonateAs' {
+                            $withNoDomainAdministratorCredential = $mockDefaultParameters.Clone()
+                            $withNoDomainAdministratorCredential.Remove('DomainAdministratorCredential')
+                            Mock -CommandName Set-ImpersonateAs -MockWith {Return 0}
+
+                            {Set-TargetResource @withNoDomainAdministratorCredential} | Should Not Throw
+
+                            Assert-MockCalled -CommandName Set-ImpersonateAs -Exactly -Times 0 -Scope It
+                        }
+                    }
                 }
             }
 
@@ -468,6 +530,22 @@ foreach ($moduleVersion in @('2012', '2016'))
 
                         $mockCorrectErrorRecord = Get-InvalidOperationRecord -Message $script:localizedData.TargetNodeDomainMissing
                         { Test-TargetResource @mockDefaultParameters } | Should -Throw $mockCorrectErrorRecord
+                    }
+                }
+
+                Context 'When no DomainAdministratorCredential is provided' {
+                    $mockDynamicDomainName = $mockDomainName
+                    $mockDynamicServerName = $mockServerName
+
+                    It 'Should not call Set-ImpersonateAs' {
+                        Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter -Verifiable
+
+                        $withNoDomainAdministratorCredential = $mockDefaultParameters.Clone()
+                        $withNoDomainAdministratorCredential.Remove('DomainAdministratorCredential')
+                        Mock -CommandName Set-ImpersonateAs -MockWith {Return 0}
+
+                        $testTargetResourceResult = Test-TargetResource @withNoDomainAdministratorCredential
+                        Assert-MockCalled -CommandName Set-ImpersonateAs -Exactly -Times 0 -Scope It
                     }
                 }
 


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->
This PR makes the DomainAdministratorCredential parameter optional for xCluster. 
In order to fulfill the use-case where Cluster Name Objects are prestaged in Active Directory 
prior to cluster creation as per [microsoft docs](https://docs.microsoft.com/en-us/windows-server/failover-clustering/prestage-cluster-adds). 

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list of the issues using a GitHub closing keyword, e.g.:
-->
- Fixes  #164 
- Fixes #70 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xfailovercluster/249)
<!-- Reviewable:end -->
